### PR TITLE
use sendgrid for sending emails

### DIFF
--- a/forms/settings.py
+++ b/forms/settings.py
@@ -6,11 +6,12 @@ DEBUG = os.getenv('DEBUG') in ['True', 'true', '1', 'yes']
 
 NONCE_SECRET = os.getenv('NONCE_SECRET')
 REDIS_URL = os.getenv('REDISTOGO_URL') or os.getenv('REDISGREEN_URL') or 'http://localhost:6379'
-MAILGUN_API_KEY = os.getenv('MAILGUN_API_KEY')
-MAILGUN_DOMAIN = os.getenv('MAILGUN_DOMAIN')
 
 SERVICE_NAME = os.getenv('SERVICE_NAME') or 'Forms'
 SERVICE_URL = os.getenv('SERVICE_URL') or 'http://example.com'
 CONTACT_EMAIL = os.getenv('CONTACT_EMAIL') or 'team@example.com'
 DEFAULT_SENDER = os.getenv('DEFAULT_SENDER') or 'Forms Team <submissions@example.com>'
 API_ROOT = os.getenv('API_ROOT') or '//example.com'
+
+SENDGRID_API_USER = os.getenv('SENDGRID_API_USER')
+SENDGRID_API_KEY = os.getenv('SENDGRID_API_KEY')


### PR DESCRIPTION
https://assembly.com/formspree/bounties/5

---

Sendgrid [doesn't support sending from our own domain](https://sendgrid.com/docs/User_Guide/whitelabel_wizard.html) for accounts lower than the Silver plan, so we can use the `DEFAULT_SENDER` we're already using and no DNS configurations have to take place now, the problem is that the emails will be sent in fact with a sendgrid domain as the original verified sender and Gmail (maybe others) will display our emails with a nice `via sendgrid.info`.

For generating an API user and key, go to https://sendgrid.com/credentials