### PR TITLE
Bounty #18: Add Log Level to settings

### DIFF
--- a/formspree/settings.py
+++ b/formspree/settings.py
@@ -7,6 +7,7 @@ DEBUG = os.getenv('DEBUG') in ['True', 'true', '1', 'yes']
 if DEBUG:
     SQLALCHEMY_ECHO = True
 
+LOG_LEVEL = os.getenv('LOG_LEVEL') or 'debug'
 NONCE_SECRET = os.getenv('NONCE_SECRET')
 SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL')
 


### PR DESCRIPTION
Adds the `LOG_LEVEL` setting to `settings.py`.

Set from an environment variable named `LOG_LEVEL` and with a default value of `debug`.