### PR TITLE
Testing refactor

### DIFF
--- a/formspree/app.py
+++ b/formspree/app.py
@@ -2,17 +2,24 @@ import flask
 from flask import g
 from flask.ext.sqlalchemy import SQLAlchemy
 from flask.ext.login import LoginManager, current_user
-import fakeredis, redis
+import redis
 import settings
-
-DB = SQLAlchemy()
-if settings.TESTING:
-    REDIS = fakeredis.FakeStrictRedis()
-else:
-    REDIS = redis.StrictRedis.from_url(settings.REDIS_URL)
-
 import routes
 from users.models import User
+
+DB = SQLAlchemy()
+_redis = None
+
+def REDIS():
+    ''' function to acquire the global redis connection '''
+    global _redis
+    if not _redis:
+        _redis = get_redis()
+    return _redis
+
+def get_redis(): 
+    ''' this may be overridden, for example to setup testing '''
+    return redis.StrictRedis.from_url(settings.REDIS_URL)
 
 def configure_login(app):
     login_manager = LoginManager()

--- a/formspree/app.py
+++ b/formspree/app.py
@@ -4,11 +4,11 @@ from flask.ext.sqlalchemy import SQLAlchemy
 from flask.ext.login import LoginManager, current_user
 import redis
 import settings
-import routes
-from users.models import User
+
 
 DB = SQLAlchemy()
 _redis = None
+
 
 def REDIS():
     ''' function to acquire the global redis connection '''
@@ -17,9 +17,15 @@ def REDIS():
         _redis = get_redis()
     return _redis
 
+
 def get_redis(): 
     ''' this may be overridden, for example to setup testing '''
     return redis.StrictRedis.from_url(settings.REDIS_URL)
+
+
+import routes
+from users.models import User
+
 
 def configure_login(app):
     login_manager = LoginManager()
@@ -34,6 +40,7 @@ def configure_login(app):
     @app.before_request
     def before_request():
         g.user = current_user
+
 
 def create_app():
     app = flask.Flask(__name__)

--- a/formspree/forms/models.py
+++ b/formspree/forms/models.py
@@ -104,15 +104,15 @@ class Form(DB.Model):
         basedate = basedate or datetime.datetime.now()
         month = basedate.month
         key = MONTHLY_COUNTER_KEY(form_id=self.id, month=month)
-        counter = REDIS.get(key) or 0
+        counter = REDIS().get(key) or 0
         return int(counter)
 
     def increase_monthly_counter(self, basedate=None):
         basedate = basedate or datetime.datetime.now()
         month = basedate.month
         key = MONTHLY_COUNTER_KEY(form_id=self.id, month=month)
-        REDIS.incr(key)
-        REDIS.expireat(key, unix_time_for_12_months_from_now(basedate))
+        REDIS().incr(key)
+        REDIS().expireat(key, unix_time_for_12_months_from_now(basedate))
 
     @staticmethod
     def send_confirmation(email, host):

--- a/formspree/settings.py
+++ b/formspree/settings.py
@@ -8,14 +8,12 @@ DEBUG = os.getenv('DEBUG') in ['True', 'true', '1', 'yes']
 if DEBUG:
     SQLALCHEMY_ECHO = True
 
-TESTING = True if 'test' in sys.argv else False
-TEST_DATABASE = os.getenv('TEST_DATABASE_URL')
-SQLALCHEMY_DATABASE_URI = TEST_DATABASE if TESTING else os.getenv('DATABASE_URL')
+SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL')
 
 LOG_LEVEL = os.getenv('LOG_LEVEL') or 'debug'
 NONCE_SECRET = os.getenv('NONCE_SECRET')
 
-MONTHLY_SUBMISSIONS_LIMIT = 2 if TESTING else int(os.getenv('MONTHLY_SUBMISSIONS_LIMIT') or 1000)
+MONTHLY_SUBMISSIONS_LIMIT = int(os.getenv('MONTHLY_SUBMISSIONS_LIMIT') or 1000)
 REDIS_URL = os.getenv('REDISTOGO_URL')
 
 SERVICE_NAME = os.getenv('SERVICE_NAME') or 'Forms'

--- a/formspree/static_pages/views.py
+++ b/formspree/static_pages/views.py
@@ -1,4 +1,4 @@
-from flask import request, render_template
+from flask import request, render_template, redirect, url_for
 
 def default(template='index'):
     template = template if template.endswith('.html') else template+'.html'
@@ -13,4 +13,4 @@ def page_not_found(e):
     return render_template('error.html', title='Oops, page not found'), 404
 
 def favicon():
-    return flask.redirect(url_for('static', filename='img/favicon.ico'))
+    return redirect(url_for('static', filename='img/favicon.ico'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ flask
 flask-script
 flask-sqlalchemy
 flask-migrate
+flask-testing
 requests==2.0.0
 paste
 gunicorn

--- a/tests/formspree_test_case.py
+++ b/tests/formspree_test_case.py
@@ -1,0 +1,34 @@
+
+import os
+import fakeredis
+
+from flask.ext.testing import TestCase
+import formspree
+from formspree import create_app
+from formspree import settings
+from formspree.app import DB, REDIS
+
+
+class FormspreeTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        ''' configures app for testing '''
+        formspree.app.get_redis = lambda : fakeredis.FakeStrictRedis()
+        settings.MONTHLY_SUBMISSIONS_LIMIT = 2
+        settings.SQLALCHEMY_DATABASE_URI = os.getenv('TEST_DATABASE_URL')
+
+    def create_app(self):        
+        app = create_app()
+        return app
+
+    def setUp(self):
+        self.assertNotEqual(settings.SQLALCHEMY_DATABASE_URI, os.getenv('DATABASE_URL'))
+        self.assertEqual(type(REDIS()), fakeredis.FakeStrictRedis)
+        self.tearDown()
+        DB.create_all()
+
+    def tearDown(self):
+        DB.session.remove()
+        DB.drop_all()
+        REDIS().flushdb()


### PR DESCRIPTION
I wanted to get a more standard test runner. Now you can run `python -m unittest discover` to kickoff all tests located in the tests folder. New files with the name test_xxx.py can be included in the tests folder, including subclasses of FormspreeTestCase, that will be run automatically.