### PR TITLE
Enable installation of web components through bower

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+   "directory" : "formspree/static/bower_components"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ pro.env
 celerybeat-schedule.db
 .Python
 include
+
+bower_components/

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,23 @@
+{
+  "name": "formspree",
+  "version": "0.0.0",
+  "homepage": "https://github.com/asm-products/formspree",
+  "authors": [],
+  "moduleType": [
+    "globals"
+  ],
+  "license": "MIT",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "formspree/static/bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "jquery": "~2.1.3",
+    "bootstrap": "~3.3.2"
+  }
+}


### PR DESCRIPTION
I decided to make this a tiny PR, because others can take advantage of that while I am doing the bounty 14.

Now you can for example, run: `bower install jquery` and refer it in your templates.