### PR TITLE
Enable travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ python:
   - "3.4"
 install: "pip install -r requirements.txt"
 script: "python manage.py test"
+env:
+  - REDISTOGO_URL='0.0.0.0:6379' TEST_DATABASE_URL=sqlite:// NONCE_SECRET='y0ur_n0nc3_s3cr3t' SECRET_KEY='y0ur_s3cr3t_k3y'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python:
+  - "2.7"
+  - "3.4"
+install: "pip install -r requirements.txt"
+script: "python manage.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
 install: "pip install -r requirements.txt"
 script: "python manage.py test"
 env:


### PR DESCRIPTION
Integrate with Travis to run our tests, so we can have a CI. Later we can pick multiple versions of Python or third-party-libraries to test so we don't have to. :smile_cat: 