### PR TITLE
Replace Mailgun by Sendgrid since we are using the last, add link to service and it's privacy policy.

### DIFF
--- a/formspree/forms/helpers.py
+++ b/formspree/forms/helpers.py
@@ -60,7 +60,7 @@ def http_form_to_dict(data):
 
 def send_email(to=None, subject=None, text=None, html=None, sender=None, cc=None, reply_to=None):
     '''
-    Sends email using Mailgun's REST-api
+    Sends email using Sendgrid Web API.
     '''
 
     if None in [to, subject, text, sender]:

--- a/formspree/templates/static_pages/index.html
+++ b/formspree/templates/static_pages/index.html
@@ -98,7 +98,7 @@
             <div class="col-1-2">
                 <div class="card">
                     <h4>What about privacy?</h4>
-                    <p>We don't store contents of the form submissions. Emails are sent using Mailgun's API, so on that end their privacy policies apply.</p>
+                    <p>We don't store contents of the form submissions. Emails are sent using <a href="https://sendgrid.com">Sendgrid's</a> API, so on that end their <a href="https://sendgrid.com/privacy">privacy policies</a> apply.</p>
                 </div>
             </div>
       </div>


### PR DESCRIPTION
- Since we are using Sendgrid's API, I replaced Mailgun by Sendgrid.
- I also added a link to Sendgrid home page and privacy policy.