### PR TITLE
Fixes CORS on ajax calls

### DIFF
--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -10,6 +10,7 @@ from formspree.app import DB
 from models import Form, Submission
 from formspree import settings
 
+@cross_origin(allow_headers=['Accept', 'Content-Type', 'X-Requested-With'])
 def thanks():
     return render_template('forms/thanks.html')
 


### PR DESCRIPTION
When you use $.ajax to submit (email) a form - the CORS headers are correct for the POST (form) but not for the _next redirect (thanks page).

Repo:
* Use $.ajax to post form

Expected:
* $.ajax.success method to execute

Actual:
* $.ajax.error method excutes

TL;DR;

Example Hack to make it work:
* http://caseman72.github.io/startbootstrap-clean-blog-jekyll/contact/

Code:
```
$.ajax({
    url: "//formspree.io/" + to,
    type: "POST",
    crossDomain: true,
    data: {
        name: name,
        phone: phone,
        email: email,
        message: message,
        _next: "//formspree.io/" + to // this has the right headers but fails with a 405 (expecting POST)
    },
    cache: false,
    success: function() {
        fx_success();
    },
    error: function(xhr) {
        xhr.status === 405 ? fx_success() : fx_error();
    }
})
```
Link:
https://github.com/caseman72/startbootstrap-clean-blog-jekyll/blob/gh-pages/js/clean-blog.js
