### PR TITLE
send form data inside a <pre> instead of using |nl2br|safe.

### DIFF
--- a/formspree/app.py
+++ b/formspree/app.py
@@ -38,7 +38,6 @@ def create_app():
     routes.configure_routes(app)
     configure_login(app)
 
-    app.jinja_env.filters['nl2br'] = lambda value: value.replace('\n','<br>\n')
     app.jinja_env.filters['json'] = json.dumps
 
     return app

--- a/formspree/templates/email/form.html
+++ b/formspree/templates/email/form.html
@@ -10,7 +10,9 @@
     {% for k in keys %}
         <tr>
             <td align="right" valign="top" width="70" style="padding: 5px 5px 5px 0;"><strong>{{k}}:</strong> </td>
-            <td align="left" valign="top" width="*" style="padding: 5px 5px 5px;">{{data.get(k,'')|nl2br|safe}}</td>
+            <td align="left" valign="top" width="*" style="padding: 5px 5px 5px;">
+              <pre style="margin: 0; font-family: inherit;">{{data.get(k,'')}}</pre>
+            </td>
         </tr>
     {% endfor %}
 </table>


### PR DESCRIPTION
What happens today when we send HTML or indented text with Formspree:

![](http://i.imgur.com/s5UFmDT.png)
![](http://i.imgur.com/7pmgwSH.png)

What happens after this commit:

![](http://i.imgur.com/KXeULNL.png)
![](http://i.imgur.com/BkhnpwW.png)