### PR TITLE
Assembly to GitHub

### DIFF
--- a/formspree/templates/static_pages/index.html
+++ b/formspree/templates/static_pages/index.html
@@ -73,8 +73,7 @@
             <div class="col-1-2">
                 <div class="card">
                     <h4>Who are you guys?</h4>
-                    <p>We're a community of developers that work together to create products. You can find us on <a href="https://assembly.com/formspree">assembly</a>. {{config.SERVICE_NAME}} is a project that solves a problem many of us have faced: easily adding forms to otherwise static HTML pages.</p>
-                </div>
+                    <p>We're a community of developers that work together to create products. You can contribute on <a href="https://github.com/asm-products/formspree">GitHub</a>. {{config.SERVICE_NAME}} is a project that solves a problem many of us have faced: easily adding forms to otherwise static HTML pages.</p>
             </div>
             <div class="col-1-2">
                 <div class="card">
@@ -224,7 +223,7 @@
   <div class="row section">
       <div class="container narrow block">
           <div class="col-1-2">
-            <p>{{config.SERVICE_NAME}} is a tool maintained by the <a href="http://assembly.com/formspree">community at Assembly</a>. To contact us send an email to <a href="mailto:{{config.CONTACT_EMAIL}}">{{config.CONTACT_EMAIL}}</a> or use the form on the right.</p>
+            <p>{{config.SERVICE_NAME}} is a tool <a href="https://github.com/asm-products/formspree">managed on Github</a>. To contact us send an email to <a href="mailto:{{config.CONTACT_EMAIL}}">{{config.CONTACT_EMAIL}}</a> or use the form on the right.</p>
           </div>
           <div class="col-1-2">
             <form method="POST" action="//{{config.API_ROOT}}/{{config.CONTACT_EMAIL}}">

--- a/formspree/templates/static_pages/index.html
+++ b/formspree/templates/static_pages/index.html
@@ -74,6 +74,7 @@
                 <div class="card">
                     <h4>Who are you guys?</h4>
                     <p>We're a community of developers that work together to create products. You can contribute on <a href="https://github.com/asm-products/formspree">GitHub</a>. {{config.SERVICE_NAME}} is a project that solves a problem many of us have faced: easily adding forms to otherwise static HTML pages.</p>
+            	</div>
             </div>
             <div class="col-1-2">
                 <div class="card">


### PR DESCRIPTION
Reduce user confusion that Formspree is shutting down by replacing dead links to Assembly with GitHub links