### PR TITLE
Put formspree gold info into the footer

### DIFF
--- a/formspree/settings.py
+++ b/formspree/settings.py
@@ -22,6 +22,7 @@ REDIS_URL = os.getenv('REDISTOGO_URL') or os.getenv('REDISCLOUD_URL')
 SERVICE_NAME = os.getenv('SERVICE_NAME') or 'Forms'
 UPGRADED_PLAN_NAME = os.getenv('UPGRADED_PLAN_NAME') or 'Gold'
 SERVICE_URL = os.getenv('SERVICE_URL') or 'http://example.com'
+SERVICE_UPGRADE = os.getenv('SERVICE_UPGRADE') or 'https://formspree.io/account'
 CONTACT_EMAIL = os.getenv('CONTACT_EMAIL') or 'team@example.com'
 DEFAULT_SENDER = os.getenv('DEFAULT_SENDER') or 'Forms Team <submissions@example.com>'
 ACCOUNT_SENDER = os.getenv('ACCOUNT_SENDER') or DEFAULT_SENDER

--- a/formspree/templates/email/form.html
+++ b/formspree/templates/email/form.html
@@ -19,4 +19,6 @@
 
 <hr style="color: #ddd;" />
 
+<p>Want even more features? You can now upgrade to <a href="{{config.SERVICE_UPGRADE}}">Formspree Gold</a>, featuring unlimited form submissions, invisible emails, and a submissions archive.</p>
+
 <p>You are receiving this because you confirmed this email address on <a href="{{config.SERVICE_URL}}">{{config.SERVICE_NAME}}</a>. If you don't remember doing that, or no longer wish to receive these emails, please remove the form on {{host}} or send an email to {{config.CONTACT_EMAIL}}.</p>

--- a/formspree/templates/static_pages/index.html
+++ b/formspree/templates/static_pages/index.html
@@ -224,7 +224,7 @@
   <div class="row section">
       <div class="container narrow block">
           <div class="col-1-2">
-            <p>{{config.SERVICE_NAME}} is a tool maintained by the <a href="http://assembly.com/formspree">community at Assembly</a>. To contact us send an email to <a href="mailto:{{config.CONTACT_EMAIL}}">{{config.CONTACT_EMAIL}}</a> or use the form on the right.</p>
+            <p>{{config.SERVICE_NAME}} is a tool <a href="https://github.com/asm-products/formspree">managed on GitHub</a>. To contact us send an email to <a href="mailto:{{config.CONTACT_EMAIL}}">{{config.CONTACT_EMAIL}}</a> or use the form on the right.</p>
           </div>
           <div class="col-1-2">
             <form method="POST" action="//{{config.API_ROOT}}/{{config.CONTACT_EMAIL}}">


### PR DESCRIPTION
Users will now see link to upgrade to formspree gold at the bottom of every submission email.