### PR TITLE
Send first form submission along with confirmation email

### DIFF
--- a/formspree/forms/models.py
+++ b/formspree/forms/models.py
@@ -183,7 +183,7 @@ class Form(DB.Model):
         redis_store.incr(key)
         redis_store.expireat(key, unix_time_for_12_months_from_now(basedate))
 
-    def send_confirmation(self):
+    def send_confirmation(self, with_data=None):
         '''
         Helper that actually creates confirmation nonce
         and sends the email to associated email. Renders
@@ -203,10 +203,15 @@ class Form(DB.Model):
         link = url_for('confirm_email', nonce=nonce, _external=True)
 
         def render_content(type):
+            data, keys = None, None
+            if with_data:
+                data, keys = http_form_to_dict(with_data)
             return render_template('email/confirm.%s' % type,
                                       email=self.email,
                                       host=self.host,
-                                      nonce_link=link)
+                                      nonce_link=link,
+                                      data=data,
+                                      keys=keys)
 
         log.debug('Sending email')
 

--- a/formspree/forms/views.py
+++ b/formspree/forms/views.py
@@ -90,7 +90,7 @@ def send(email_or_string):
     if form.confirmed:
         status = form.send(request.form, request.referrer)
     else:
-        status = form.send_confirmation()
+        status = form.send_confirmation(with_data=request.form)
 
     # Respond to the request accordingly to the status code
     if status['code'] == Form.STATUS_EMAIL_SENT:

--- a/formspree/templates/email/confirm.html
+++ b/formspree/templates/email/confirm.html
@@ -21,6 +21,8 @@
     </div>
 {% endif %}
 
+<p style="text-align: center; font-size: 25px;">Attention: you will not receive any more emails unless you click <a href="{{nonce_link}}">here</a> and confirm your address.</p>
+
 <p>We hope you enjoy using {{config.SERVICE_NAME}}. If you have any questions, feel free to shoot an email to {{config.CONTACT_EMAIL}}</p>
 
 <p>Best,<br />

--- a/formspree/templates/email/confirm.html
+++ b/formspree/templates/email/confirm.html
@@ -4,6 +4,25 @@
 
 <p><a href="{{nonce_link}}">Click here to confirm</a></p>
 
+{% if data and keys %}
+    <hr style="color: #ddd;" />
+    
+    <p>In case it wasn't yourself the one who submitted this, here are the contents of the form:</p>
+    
+    <table border="0" width="100%">
+        {% for k in keys %}
+            <tr>
+                <td align="right" valign="top" width="70" style="padding: 5px 5px 5px 0;"><strong>{{k}}:</strong> </td>
+                <td align="left" valign="top" width="*" style="padding: 5px 5px 5px;">
+                  <pre style="margin: 0; font-family: inherit;">{{data.get(k,'')}}</pre>
+                </td>
+            </tr>
+        {% endfor %}
+    </table>
+    
+    <hr style="color: #ddd;" />
+{% endif %}
+
 <p>We hope you enjoy using {{config.SERVICE_NAME}}. If you have any questions, feel free to shoot an email to {{config.CONTACT_EMAIL}}</p>
 
 <p>Best,<br />

--- a/formspree/templates/email/confirm.html
+++ b/formspree/templates/email/confirm.html
@@ -2,25 +2,23 @@
 
 <p>All you have to do is click the link below to confirm your email. To prevent spamming, you'll have to repeat this step for every page where you insert your form. Note that you won't be receiving any emails from the site before you confirm your email.</p>
 
-<p><a href="{{nonce_link}}">Click here to confirm</a></p>
+<p style="text-align: center"><a href="{{nonce_link}}" style="font-size: 20px;">Click here to confirm</a></p>
 
 {% if data and keys %}
-    <hr style="color: #ddd;" />
-    
-    <p>In case it wasn't yourself the one who submitted this, here are the contents of the form:</p>
-    
-    <table border="0" width="100%">
-        {% for k in keys %}
-            <tr>
-                <td align="right" valign="top" width="70" style="padding: 5px 5px 5px 0;"><strong>{{k}}:</strong> </td>
-                <td align="left" valign="top" width="*" style="padding: 5px 5px 5px;">
-                  <pre style="margin: 0; font-family: inherit;">{{data.get(k,'')}}</pre>
-                </td>
-            </tr>
-        {% endfor %}
-    </table>
-    
-    <hr style="color: #ddd;" />
+    <div style="padding: 9px; border: 1px solid #359173;">
+        <small>In case it wasn't yourself the one who submitted this, here are the contents of the form:</small>
+
+        <table border="0" width="100%" style="font-size: 11px;">
+            {% for k in keys %}
+                <tr>
+                    <td align="right" valign="top" width="70"><strong>{{k}}:</strong> </td>
+                    <td align="left" valign="top" width="*">
+                      <pre style="margin: 0; font-family: inherit;">{{data.get(k,'')}}</pre>
+                    </td>
+                </tr>
+            {% endfor %}
+        </table>
+    </div>
 {% endif %}
 
 <p>We hope you enjoy using {{config.SERVICE_NAME}}. If you have any questions, feel free to shoot an email to {{config.CONTACT_EMAIL}}</p>
@@ -28,7 +26,7 @@
 <p>Best,<br />
 Lauri and Cole</p>
 
-<hr />
+<hr style="color: #359173; border: 1px dashed #359173;" />
 
 <p><strong>Why did I receive this email?</strong><br />
 Someone (hopefully you?) used your email with the {{config.SERVICE_NAME}} API on {{host}}. If this wasn't you, no worries. This is the only email you'll get.</p>

--- a/formspree/templates/email/confirm.txt
+++ b/formspree/templates/email/confirm.txt
@@ -4,6 +4,16 @@ All you have to do is click the link below to confirm your email. To prevent spa
 
 Link: {{nonce_link}}
 
+{% if data and keys %}
+    In case it wasn't yourself the one who submitted this, here are the contents of the form:
+
+    {% for k in keys %}
+    {{k}}:
+    {{data[k]}}
+
+    {% endfor %}
+{% endif %}
+
 We hope you enjoy using {{config.SERVICE_NAME}}. If you have any questions, feel free to shoot an email to {{config.CONTACT_EMAIL}}.
 
 Best,

--- a/formspree/templates/email/form.html
+++ b/formspree/templates/email/form.html
@@ -4,7 +4,7 @@
 
 <p>Here's what they had to say:</p>
 
-<hr style="color: #ddd;" />
+<hr style="color: #359173; border: 1px dashed #359173;">
 
 <table border="0" width="100%">
     {% for k in keys %}
@@ -19,6 +19,6 @@
 
 <small style="margin-left: 10px; font-size: 10px;">This form was submitted at {{ now }}.</small>
 
-<hr style="color: #ddd;" />
+<hr style="color: #359173; border: 1px dashed #359173;" />
 
 <p>You are receiving this because you confirmed this email address on <a href="{{config.SERVICE_URL}}">{{config.SERVICE_NAME}}</a>. If you don't remember doing that, or no longer wish to receive these emails, please remove the form on {{host}} or send an email to {{config.CONTACT_EMAIL}}.</p>


### PR DESCRIPTION
As suggested [here](https://trello.com/c/CzyN0Y8M/1138-storing-submissions-before-email-verification).

I have zero design skills, but anyway I had to accommodate the form contents inside the confirmation email, so I made some small changes:

![confirmation](https://cloud.githubusercontent.com/assets/1653275/11423001/dcb89bfe-9427-11e5-8f00-246ceb55b0df.png)
![submission](https://cloud.githubusercontent.com/assets/1653275/11423004/de082ca4-9427-11e5-89cb-08585a867b28.png)

Please make corrections and suggestions.